### PR TITLE
ga-migration: fix various problems

### DIFF
--- a/automation_tools/scripts/ga-migration/main.py
+++ b/automation_tools/scripts/ga-migration/main.py
@@ -100,8 +100,8 @@ def migrate_repo(path):
 
     # Upgrade Sphinx 1 to 3 in setup.py
     replace_regex(
-        r"Sphinx>=1.[0-9].[0-9]",
-        "Sphinx>=3",
+        r"Sphinx>=1.[0-9](.[0-9])?.*,",
+        "Sphinx>=3',",
         path + "setup.py",
     )
 

--- a/automation_tools/scripts/ga-migration/templates/serviceless/tests.yml
+++ b/automation_tools/scripts/ga-migration/templates/serviceless/tests.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Run tests
         run: |
           ./run-tests.sh
-{% endraw %}
+{%- endraw %}

--- a/automation_tools/scripts/ga-migration/templates/services/tests.yml
+++ b/automation_tools/scripts/ga-migration/templates/services/tests.yml
@@ -79,7 +79,9 @@ jobs:
             db-service: mysql5
           {%- endif %}
 
+          {%- if db or search %}
           include:
+          {%- endif %}
           {%- if db %}
           - db-service: postgresql9
             DB_EXTRAS: "postgresql"
@@ -148,4 +150,4 @@ jobs:
       - name: Run tests
         run: |
           ./run-tests.sh
-{% endraw %}
+{%- endraw %}

--- a/automation_tools/scripts/ga-migration/utils.py
+++ b/automation_tools/scripts/ga-migration/utils.py
@@ -17,7 +17,8 @@ logging.basicConfig(level=logging.INFO)
 JinjaEnv = Environment(
     loader=FileSystemLoader(
         f"{os.path.join(os.path.dirname(__file__))}/templates"
-    )
+    ),
+    keep_trailing_newline=True
 )
 
 
@@ -258,7 +259,8 @@ def replace_list(filepath, regex, to_remove, to_add, var_name):
         #  Dump JSON with 4 spaces indent to keep setup.py formatted
         #  Must be kept in-sync with the indent_size value in
         #   .editorconfig / project setups
-        py_new_string = f"{var_name} = {json.dumps(new_list, indent=4)}"
+        formatted_list = json.dumps(new_list, indent=4).replace('"', "'")
+        py_new_string = f"{var_name} = {formatted_list}"
 
         # Replace the old (matched) list assignment with the one with the new contents
         content2 = contents.replace(m.group(0), py_new_string)


### PR DESCRIPTION
- Catch also Sphinx versions with only 2 digits (x.y).
- Keep trailing newline in Jinja templates.
- Fix issue adding empty `include: ` section in GA tests.yaml.
- Replace double quotes with single quotes in `replace_list`.
