### PR TITLE
ga-migration: fix sphinx regex

### DIFF
--- a/automation_tools/scripts/ga-migration/main.py
+++ b/automation_tools/scripts/ga-migration/main.py
@@ -94,11 +94,14 @@ def migrate_repo(path):
     # Delete travis file
     delete_file(path + ".travis.yml")
 
-    # Upgrade Sphinx 1 to 3 in setup.py
+    # Upgrade from any Sphinx version to 3 in setup.py
     replace_regex(
-        r"Sphinx>=1.[0-9](.[0-9])?.*,",
-        "Sphinx>=3',",
+        # Quote - package name, version (separated with commas) range - Quote
+        r"(\"|')(Sphinx.*)(\"|')",
+        "Sphinx>=3",
         path + "setup.py",
+        # Replace the second matching group only (excludes the outer quotes)
+        2
     )
 
     # Simplify setup.py test requirements replacing them with pytest-invenio

--- a/automation_tools/scripts/ga-migration/utils.py
+++ b/automation_tools/scripts/ga-migration/utils.py
@@ -186,7 +186,7 @@ def replace_simple(text, replacing, filepath):
         logging.info("No %s found" % filepath)
 
 
-def replace_regex(regex, output, filepath):
+def replace_regex(regex, output, filepath, replace_group=0):
     """
     Replaces every match of a string with another in the specified file
     """
@@ -196,7 +196,19 @@ def replace_regex(regex, output, filepath):
         # TODO: expose number of matches
         with fileinput.FileInput(filepath, inplace=True, backup=".bak") as file:
             for line in file:
-                print(re.sub(regex, output, line), end="")
+                if replace_group == 0:
+                    print(re.sub(regex, output, line), end="")
+                else:
+                    # Match regex in line
+                    m = re.search(regex, line)
+                    if m:
+                        # Get the requested group
+                        matched_group = m.group(replace_group)
+                        # Replace the matched group with the given text
+                        print(re.sub(matched_group, output, line), end="")
+                    else:
+                        print(re.sub(regex, output, line), end="")
+
     else:
         logging.info("SKIPPED TASK. No %s found" % filepath)
 


### PR DESCRIPTION
This should fix the regex breaking the Sphinx upgrade when the file had double quotes and not single ones (bug introduced here: https://github.com/inveniosoftware/automation-tools/blame/3bf0d14e168bba794d59b92d6324b80e92a93dcc/automation_tools/scripts/ga-migration/main.py#L100)

closes #22 